### PR TITLE
added deployment config and build config for orders microservice

### DIFF
--- a/deploy/openshift/builds/orders.yaml
+++ b/deploy/openshift/builds/orders.yaml
@@ -1,0 +1,26 @@
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: orders
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: orders-build
+spec:
+  source:
+    git:
+      uri: "https://github.com/Liatrio-LOK/orders"
+      ref: "master"
+    type: Git
+  strategy:
+    sourceStrategy:
+      from:
+        kind: "DockerImage"
+        name: "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift"
+  output:
+    to:
+      kind: ImageStreamTag
+      name: orders:latest
+      namespace: sock-shop
+

--- a/deploy/openshift/complete-demo-deployment-configs.yaml
+++ b/deploy/openshift/complete-demo-deployment-configs.yaml
@@ -316,32 +316,52 @@ spec:
   selector:
     name: orders-db
 ---
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: DeploymentConfig
 metadata:
   name: orders
-  labels:
-    name: orders
   namespace: sock-shop
+  selfLink: /oapi/v1/namespaces/sock-shop/deploymentconfigs/orders
 spec:
   replicas: 1
+  selector:
+    name: orders
+  strategy:
+    activeDeadlineSeconds: 21600
+    resources: {}
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
   template:
     metadata:
+      creationTimestamp: null
       labels:
         name: orders
     spec:
       containers:
-      - name: orders
-        image: weaveworksdemos/orders:0.4.7
+      - image: 172.30.1.1:5000/sock-shop/orders
+        imagePullPolicy: IfNotPresent
+        name: orders
+        ports:
+        - containerPort: 8082
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: false
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
         env:
          - name: ZIPKIN
            value: zipkin.zipkin.svc.cluster.local
          - name: JAVA_OPTS
            value: -Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom
-        ports:
-        - containerPort: 80
-        securityContext:
-          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
           name: tmp-volume
@@ -349,8 +369,39 @@ spec:
         - name: tmp-volume
           emptyDir:
             medium: Memory
+      dnsPolicy: ClusterFirst
       nodeSelector:
         beta.kubernetes.io/os: linux
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+  - type: ConfigChange
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - orders
+      from:
+        kind: ImageStreamTag
+        name: orders:latest
+        namespace: sock-shop
+    type: ImageChange
+status:
+  availableReplicas: 1
+  conditions:
+  details:
+    causes:
+    - imageTrigger:
+        from:
+          kind: ImageStreamTag
+          name: orders:latest
+          namespace: sock-shop
+      type: ImageChange
+    message: image change
+  readyReplicas: 1
+  replicas: 1
 ---
 apiVersion: v1
 kind: Service
@@ -363,7 +414,7 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: 8082
   selector:
     name: orders
 ---


### PR DESCRIPTION
Set up build config and deployment config for the orders microservice. It uses java1.8 s2i.

In order to test on minishift
oc create -f microservices-demo/deploy/openshift/complete-demo-deployment-configs.yaml
oc create -f microservices-demo/deploy/openshift/builds/front-end.yaml
oc create -f microservices-demo/deploy/openshift/builds/orders.yaml

Trigger the builds for front-end and orders. If there are problems spinning up the databases it is likely because they need elevated priviledges the following commands will allow any authenticated user to deploy priviledged containers:
oc login -u system:admin
oc adm policy add-scc-to-group anyuid system:authenticated