### PR TITLE
Lok 134 queue

### DIFF
--- a/deploy/openshift/builds/queue-master.yaml
+++ b/deploy/openshift/builds/queue-master.yaml
@@ -1,0 +1,26 @@
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: queue-master
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: queue-master-build
+spec:
+  source:
+    git:
+      uri: "https://github.com/Liatrio-LOK/queue-master"
+      ref: "master"
+    type: Git
+  strategy:
+    sourceStrategy:
+      from:
+        kind: "DockerImage"
+        name: "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift"
+  output:
+    to:
+      kind: ImageStreamTag
+      name: queue-master:latest
+      namespace: sock-shop
+

--- a/deploy/openshift/complete-demo-deployment-configs.yaml
+++ b/deploy/openshift/complete-demo-deployment-configs.yaml
@@ -457,27 +457,80 @@ spec:
   selector:
     name: payment
 ---
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: DeploymentConfig
 metadata:
   name: queue-master
-  labels:
-    name: queue-master
   namespace: sock-shop
+  selfLink: /oapi/v1/namespaces/sock-shop/deploymentconfigs/queue-master
 spec:
   replicas: 1
+  selector:
+    name: queue-master
+  strategy:
+    activeDeadlineSeconds: 21600
+    resources: {}
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
   template:
     metadata:
+      creationTimestamp: null
       labels:
         name: queue-master
     spec:
       containers:
-      - name: queue-master
-        image: weaveworksdemos/queue-master:0.3.1
+      - image: 172.30.1.1:5000/sock-shop/queue-master
+        imagePullPolicy: IfNotPresent
+        name: queue-master
         ports:
         - containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: false
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
       nodeSelector:
         beta.kubernetes.io/os: linux
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+  - type: ConfigChange
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - queue-master
+      from:
+        kind: ImageStreamTag
+        name: queue-master:latest
+        namespace: sock-shop
+    type: ImageChange
+status:
+  availableReplicas: 1
+  conditions:
+  details:
+    causes:
+    - imageTrigger:
+        from:
+          kind: ImageStreamTag
+          name: queue-master:latest
+          namespace: sock-shop
+      type: ImageChange
+    message: image change
+  readyReplicas: 1
+  replicas: 1
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/openshift/complete-demo-deployment-configs.yaml
+++ b/deploy/openshift/complete-demo-deployment-configs.yaml
@@ -488,7 +488,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: queue-master
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           protocol: TCP
         resources:
           requests:
@@ -545,7 +545,7 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: 8080
   selector:
     name: queue-master
 ---


### PR DESCRIPTION
Added buildconfig for queue-master service also changed service to use the right port. Switched from deployment to deployment config.

The queue-master service current isn't working. But it is hooked up in the same way as or other java applications. We need to look into what we want to do with this service going forward.